### PR TITLE
Add a simple .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Trying to fix #22 by preventing `semantic-release` from using what appears to be a default action runner-related npmrc file. 