### PR TITLE
Allow dependabot builds to trigger releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,10 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
-  schedule:
-    - cron: '30 18 * * 5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,13 @@
         "main"
     ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        ["@semantic-release/commit-analyzer", {
+            "preset": "angular",
+            "releaseRules": [
+                { "type": "build", "scope": "deps*", "release": "patch" },
+                { "scope": "no-release", "release": false }
+            ]
+        }],
         "@semantic-release/release-notes-generator",
         "@semantic-release/npm",
         "@semantic-release/github"


### PR DESCRIPTION
Also add concurrency settings to hopefully batch releases
when there are multiple dependabot merges in a short time

Fixes https://github.com/viamin/homebridge-rise-garden/issues/53