### PR TITLE
Unhide miscellaneous chores in release configuration

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -10,7 +10,7 @@
         {"type": "revert", "section": "Reverts", "hidden": false},
         {"type": "docs", "section": "Documentation", "hidden": false},
         {"type": "style", "section": "Styles", "hidden": true},
-        {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous Chores", "hidden": false},
         {"type": "refactor", "section": "Code Refactoring", "hidden": false},
         {"type": "test", "section": "Tests", "hidden": true},
         {"type": "build", "section": "Build System", "hidden": false},


### PR DESCRIPTION
I use the chore category for a number of tasks that seem like they should trigger a release. This should show them in the changelog. 